### PR TITLE
Fix some incorrect FFI types

### DIFF
--- a/src/SDL/TTF/FFI.hsc
+++ b/src/SDL/TTF/FFI.hsc
@@ -25,7 +25,7 @@ foreign import ccall unsafe "TTF_OpenFont"
   openFont :: CString -> CInt -> IO TTFFont
 
 foreign import ccall unsafe "TTF_OpenFontRW"
-  openFontRW :: Ptr RWops -> CInt -> IO TTFFont
+  openFontRW :: Ptr RWops -> CInt -> CInt -> IO TTFFont
 
 foreign import ccall unsafe "TTF_OpenFontIndexRW"
   openFontIndexRW :: Ptr RWops -> CInt -> CInt -> CLong -> IO TTFFont
@@ -34,7 +34,7 @@ foreign import ccall unsafe "TTF_CloseFont"
   closeFont :: TTFFont -> IO ()
  
 foreign import ccall unsafe "TTF_OpenFontIndex"
-  openFontIndex :: CString -> CInt -> CInt -> IO TTFFont
+  openFontIndex :: CString -> CInt -> CLong -> IO TTFFont
 
 foreign import ccall unsafe "TTF_GetFontStyle"
   getFontStyle :: TTFFont -> IO CInt


### PR DESCRIPTION
See the docs for [`TTF_OpenFontRW `](https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC15) and [`TTF_OpenFontIndex `](https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC16).

Dunno if this matters based on what work #2 ends up doing but figured I'd report it to be sure since the `TTF_OpenFontRW` issue causes a segfault.