### PR TITLE
Fix test instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ directory.
 
 ```bash
 cd sdl2-ttf
+cabal configure -fexample
 cabal run path/to/some/font.type
 ```


### PR DESCRIPTION
The flag prevents spurious executable compilation if the library is just used, not tested manually. So it needs to be set explicitly when testing with the executable.