### PR TITLE
Added additional high/low level bindings for the blended_wrapped functions.

### DIFF
--- a/cbits/helpers.c
+++ b/cbits/helpers.c
@@ -117,3 +117,33 @@ extern DECLSPEC SDL_Surface * SDLCALL
 
   return TTF_RenderGlyph_Blended(font, glyph, *fg);
 }
+
+extern DECLSPEC SDL_Surface * SDLCALL
+  TTF_RenderUTF8_Blended_Wrapped_p(
+    TTF_Font *font,
+    const char *text,
+    SDL_Color *fg,
+    uint32_t wrapLength) {
+
+  return TTF_RenderUTF8_Blended(font, text, *fg, wrapLength);
+}
+
+extern DECLSPEC SDL_Surface * SDLCALL
+  TTF_RenderUNICODE_Blended_Wrapped_p(
+    TTF_Font *font,
+    uint16_t *text,
+    SDL_Color *fg,
+    uint32_t wrapLength) {
+
+  return TTF_RenderUNICODE_Blended(font, text, *fg, wrapLength);
+}
+
+extern DECLSPEC SDL_Surface * SDLCALL
+  TTF_RenderText_Blended_Wrapped_p(
+    TTF_Font *font,
+    const char *text,
+    SDL_Color *fg,
+    uint32_t wrapLength) {
+
+  return TTF_RenderText_Blended(font, text, *fg, wrapLength);
+}

--- a/cbits/helpers.c
+++ b/cbits/helpers.c
@@ -125,7 +125,7 @@ extern DECLSPEC SDL_Surface * SDLCALL
     SDL_Color *fg,
     uint32_t wrapLength) {
 
-  return TTF_RenderUTF8_Blended(font, text, *fg, wrapLength);
+  return TTF_RenderUTF8_Blended_Wrapped(font, text, *fg, wrapLength);
 }
 
 extern DECLSPEC SDL_Surface * SDLCALL
@@ -135,7 +135,7 @@ extern DECLSPEC SDL_Surface * SDLCALL
     SDL_Color *fg,
     uint32_t wrapLength) {
 
-  return TTF_RenderUNICODE_Blended(font, text, *fg, wrapLength);
+  return TTF_RenderUNICODE_Blended_Wrapped(font, text, *fg, wrapLength);
 }
 
 extern DECLSPEC SDL_Surface * SDLCALL
@@ -145,5 +145,5 @@ extern DECLSPEC SDL_Surface * SDLCALL
     SDL_Color *fg,
     uint32_t wrapLength) {
 
-  return TTF_RenderText_Blended(font, text, *fg, wrapLength);
+  return TTF_RenderText_Blended_Wrapped(font, text, *fg, wrapLength);
 }

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -34,7 +34,7 @@ library
 
   pkgconfig-depends:
     sdl2 >= 2.0.3,
-    SDL2_ttf >= 2.0.0
+    SDL2_ttf >= 2.0.12
 
   c-sources:
     cbits/helpers.c

--- a/src/SDL/Font.hs
+++ b/src/SDL/Font.hs
@@ -71,6 +71,7 @@ module SDL.Font
   , ascent
   , descent
   , lineSkip
+  , getKerningSize
 
   -- * Glyphs
   --
@@ -513,3 +514,8 @@ blendedWrapped (Font font) (V4 r g b a) wrapLength text =
       liftIO . withText text $ \ptr ->
         with (SDL.Raw.Color r g b a) $ \fg ->
           SDL.Raw.Font.renderUNICODE_Blended_Wrapped font (castPtr ptr) fg $ fromIntegral wrapLength
+
+-- | From a given 'Font' get the kerning size of two glyphs.
+getKerningSize :: MonadIO m => Font -> Index -> Index -> m Int
+getKerningSize (Font font) prevIndex index =
+  fmap fromIntegral $ SDL.Raw.Font.getFontKerningSize font (fromIntegral prevIndex) (fromIntegral index)

--- a/src/SDL/Font.hs
+++ b/src/SDL/Font.hs
@@ -81,6 +81,7 @@ module SDL.Font
   , solidGlyph
   , shadedGlyph
   , blendedGlyph
+  , blendedWrapped
   ) where
 
 import Control.Exception      (throwIO)
@@ -501,3 +502,14 @@ blendedGlyph (Font font) (V4 r g b a) ch =
       liftIO .
         with (SDL.Raw.Color r g b a) $ \fg ->
           SDL.Raw.Font.renderGlyph_Blended font (fromChar ch) fg
+
+-- | Same as 'blended', but renders across multiple lines. 
+--   Text is wrapped to multiple lines on line endings and on word boundaries
+--   if it extends beyond wrapLength in pixels.
+blendedWrapped :: MonadIO m => Font -> Color -> Int -> Text -> m SDL.Surface
+blendedWrapped (Font font) (V4 r g b a) wrapLength text =
+  fmap unmanaged .
+    throwIfNull "SDL.Font.blended" "TTF_RenderUNICODE_Blended_Wrapped" .
+      liftIO . withText text $ \ptr ->
+        with (SDL.Raw.Color r g b a) $ \fg ->
+          SDL.Raw.Font.renderUNICODE_Blended_Wrapped font (castPtr ptr) fg $ fromIntegral wrapLength

--- a/src/SDL/Raw/Font.hsc
+++ b/src/SDL/Raw/Font.hsc
@@ -63,6 +63,7 @@ module SDL.Raw.Font
   , fontFaceStyleName
   , glyphIsProvided
   , glyphMetrics
+  , getFontKerningSize
 
   -- * Getting text size
   , sizeText
@@ -267,3 +268,6 @@ liftF "renderUTF8_Blended_Wrapped" "TTF_RenderUTF8_Blended_Wrapped_p"
 
 liftF "renderUNICODE_Blended_Wrapped" "TTF_RenderUNICODE_Blended_Wrapped_p"
   [t|Ptr Font -> Ptr CUShort -> Ptr Color -> CUInt -> IO (Ptr Surface)|]
+
+liftF "getFontKerningSize" "TTF_GetFontKerningSize"
+  [t|Ptr Font -> CInt -> CInt -> IO CInt|]

--- a/src/SDL/Raw/Font.hsc
+++ b/src/SDL/Raw/Font.hsc
@@ -259,7 +259,7 @@ liftF "renderUNICODE_Blended" "TTF_RenderUNICODE_Blended_p"
 liftF "renderGlyph_Blended" "TTF_RenderGlyph_Blended_p"
   [t|Ptr Font -> CUShort -> Ptr Color -> IO (Ptr Surface)|]
 
-liftF "renderText_Blended_Wrapped" "TTF_RenderText_Blended__Wrapped_p"
+liftF "renderText_Blended_Wrapped" "TTF_RenderText_Blended_Wrapped_p"
   [t|Ptr Font -> CString -> Ptr Color -> CUInt -> IO (Ptr Surface)|]
 
 liftF "renderUTF8_Blended_Wrapped" "TTF_RenderUTF8_Blended_Wrapped_p"

--- a/src/SDL/Raw/Font.hsc
+++ b/src/SDL/Raw/Font.hsc
@@ -73,12 +73,15 @@ module SDL.Raw.Font
   , renderText_Solid
   , renderText_Shaded
   , renderText_Blended
+  , renderText_Blended_Wrapped
   , renderUTF8_Solid
   , renderUTF8_Shaded
   , renderUTF8_Blended
+  , renderUTF8_Blended_Wrapped
   , renderUNICODE_Solid
   , renderUNICODE_Shaded
   , renderUNICODE_Blended
+  , renderUNICODE_Blended_Wrapped
   , renderGlyph_Solid
   , renderGlyph_Shaded
   , renderGlyph_Blended
@@ -92,7 +95,7 @@ module SDL.Raw.Font
 #include "SDL_ttf.h"
 
 import Foreign.C.String       (CString)
-import Foreign.C.Types        (CInt(..), CLong(..), CUShort(..))
+import Foreign.C.Types        (CInt(..), CLong(..), CUShort(..), CUInt(..))
 import Foreign.Ptr            (Ptr)
 import Prelude         hiding (init)
 import SDL.Raw.Types          (Version, Surface, RWops, Color)
@@ -255,3 +258,12 @@ liftF "renderUNICODE_Blended" "TTF_RenderUNICODE_Blended_p"
 
 liftF "renderGlyph_Blended" "TTF_RenderGlyph_Blended_p"
   [t|Ptr Font -> CUShort -> Ptr Color -> IO (Ptr Surface)|]
+
+liftF "renderText_Blended_Wrapped" "TTF_RenderText_Blended__Wrapped_p"
+  [t|Ptr Font -> CString -> Ptr Color -> CUInt -> IO (Ptr Surface)|]
+
+liftF "renderUTF8_Blended_Wrapped" "TTF_RenderUTF8_Blended_Wrapped_p"
+  [t|Ptr Font -> CString -> Ptr Color -> CUInt -> IO (Ptr Surface)|]
+
+liftF "renderUNICODE_Blended_Wrapped" "TTF_RenderUNICODE_Blended_Wrapped_p"
+  [t|Ptr Font -> Ptr CUShort -> Ptr Color -> CUInt -> IO (Ptr Surface)|]


### PR DESCRIPTION
There are blended_wrapped functions in the SDL2-TTF headers which were not exposed in the Haskell interface. 

Hopefully all is well. :)