### PR TITLE
Use th-abstraction to get compatible with GHC 9.0.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2020 Ömer Sinan Ağacan, Siniša Biđin, Rongcui Dong
+Copyright (c) 2013-2021 Ömer Sinan Ağacan, Siniša Biđin, Rongcui Dong
                         and others (see git commits)
 
 This code is licensed under MIT or BSD3 licenses, so that the user

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -1,5 +1,5 @@
 name:          sdl2-ttf
-version:       2.1.1
+version:       2.1.2
 synopsis:      Bindings to SDL2_ttf.
 description:   Haskell bindings to SDL2_ttf C++ library <http://www.libsdl.org/projects/SDL_ttf/>.
 bug-reports:   https://github.com/haskell-game/sdl2-ttf/issues
@@ -14,7 +14,8 @@ copyright:     Copyright © 2013-2020 Ömer Sinan Ağacan, Siniša Biđin, Rongc
 category:      Font, Foreign binding, Graphics
 build-type:    Simple
 cabal-version: >=1.10
-tested-with:   GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.2, GHC==8.6.5, GHC==8.8.3
+tested-with:   GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5,
+               GHC==8.8.4, GHC==8.10.4, GHC==9.0.1
 
 source-repository head
   type:     git
@@ -46,6 +47,7 @@ library
     sdl2             >= 2.2,
     template-haskell,
     text             >= 1.1.0.0,
+    th-abstraction   >= 0.4.0.0,
     transformers     >= 0.4
 
   default-language:

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -10,12 +10,12 @@ author:        Rongcui Dong (rongcuid@outlook.com),
                Siniša Biđin <sinisa@bidin.eu>,
                Ömer Sinan Ağacan (omeragacan@gmail.com),
                Sean Chalmers (sclhiannan@gmail.com)
-copyright:     Copyright © 2013-2020 Ömer Sinan Ağacan, Siniša Biđin, Rongcui Dong and others (see git commits)
+copyright:     Copyright © 2013-2021 Ömer Sinan Ağacan, Siniša Biđin, Rongcui Dong and others (see git commits)
 category:      Font, Foreign binding, Graphics
 build-type:    Simple
 cabal-version: >=1.10
-tested-with:   GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5,
-               GHC==8.8.4, GHC==8.10.4, GHC==9.0.1
+tested-with:   GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.4,
+               GHC==8.10.4, GHC==9.0.1
 
 source-repository head
   type:     git

--- a/src/SDL/Raw/Helper.hs
+++ b/src/SDL/Raw/Helper.hs
@@ -19,6 +19,7 @@ module SDL.Raw.Helper (liftF) where
 import Control.Monad           (replicateM)
 import Control.Monad.IO.Class  (MonadIO, liftIO)
 import Language.Haskell.TH
+import Language.Haskell.TH.Datatype.TyVarBndr (plainTVSpecified)
 
 -- | Given a name @fname@, a name of a C function @cname@ and the desired
 -- Haskell type @ftype@, this function generates:
@@ -80,7 +81,7 @@ liftType = \case
     m <- newName "m"
     return $
       ForallT
-        [PlainTV m]
+        [plainTVSpecified m]
         [AppT (ConT ''MonadIO) $ VarT m]
         (AppT (VarT m) t)
   t -> return t


### PR DESCRIPTION
This attempts to get sdl2-ttf to be compatible with GHC 9.0.1, which it probably is not, currently, as seen at

https://travis-ci.org/github/AllureOfTheStars/Allure/jobs/759908859

due to TH changes as described at

https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#template-haskell-217

Testing of compilation under various GHCs on Linux and OS X to be performed via LambdaHack CI on Travis:

https://travis-ci.org/github/LambdaHack/LambdaHack

After merging, a single test will be performed on AppVeyor for Windows.