### PR TITLE
Update to work with text >= 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Haskell bindings for the True Type Font library for SDL.
 
 - libsdl <https://www.libsdl.org>
-- sdl2-ttf <https://www.libsdl.org/projects/SDL_ttf/>
+- sdl2-ttf <https://github.com/libsdl-org/SDL_ttf>
 
 Both the raw and the higher level bindings should allow you to use any aspect
 of the original SDL2_ttf library. Please report an issue if you encounter a bug

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -45,7 +45,7 @@ library
     bytestring       >= 0.10.4.0,
     sdl2             >= 2.2,
     template-haskell,
-    text             >= 1.1.0.0,
+    text             >= 1.1.0.0 && < 2 || >= 2.0.1,
     th-abstraction   >= 0.4.0.0,
     transformers     >= 0.4
 

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -1,7 +1,7 @@
 name:          sdl2-ttf
 version:       2.1.3
 synopsis:      Bindings to SDL2_ttf.
-description:   Haskell bindings to SDL2_ttf C++ library <http://www.libsdl.org/projects/SDL_ttf/>.
+description:   Haskell bindings to SDL2_ttf C++ library <https://github.com/libsdl-org/SDL_ttf>.
 bug-reports:   https://github.com/haskell-game/sdl2-ttf/issues
 license:       BSD3
 license-file:  LICENSE

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -14,7 +14,7 @@ copyright:     Copyright © 2013-2022 Ömer Sinan Ağacan, Siniša Biđin, Rongc
 category:      Font, Foreign binding, Graphics
 build-type:    Simple
 cabal-version: >=1.10
-tested-with:   GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.3
+tested-with:   GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.3 || ==9.4
 
 source-repository head
   type:     git

--- a/src/SDL/Font.hs
+++ b/src/SDL/Font.hs
@@ -16,9 +16,7 @@ throwing an 'SDLException' in case it encounters an error.
 
 -}
 
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE DeriveGeneric, LambdaCase, OverloadedStrings #-}
 
 module SDL.Font
   (
@@ -86,27 +84,27 @@ module SDL.Font
   , blendedWrapped
   ) where
 
-import Control.Exception      (throwIO)
-import Control.Monad          (unless)
+import Control.Exception (throwIO)
+import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Bits              ((.&.), (.|.))
-import Data.ByteString        (ByteString)
-import Data.ByteString.Unsafe (unsafeUseAsCStringLen, unsafePackCString)
-import Data.Text              (Text)
-import Data.Text.Encoding     (decodeUtf8)
-import Data.Text.Foreign      (lengthWord16, unsafeCopyToPtr)
-import Data.Word              (Word8, Word16)
-import Foreign.C.String       (CString, withCString)
-import Foreign.C.Types        (CUShort, CInt)
-import Foreign.Marshal.Alloc  (allocaBytes, alloca)
-import Foreign.Marshal.Utils  (with, fromBool, toBool)
-import Foreign.Ptr            (Ptr, castPtr, nullPtr)
-import Foreign.Storable       (peek, pokeByteOff)
-import GHC.Generics           (Generic)
-import SDL                    (Surface(..), SDLException(SDLCallFailed))
+import Data.Bits ((.&.), (.|.))
+import Data.ByteString (ByteString)
+import Data.ByteString.Unsafe (unsafePackCString, unsafeUseAsCStringLen)
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Data.Text.Foreign (lengthWord16, unsafeCopyToPtr)
+import Data.Word (Word16, Word8)
+import Foreign.C.String (CString, withCString)
+import Foreign.C.Types (CInt, CUShort)
+import Foreign.Marshal.Alloc (alloca, allocaBytes)
+import Foreign.Marshal.Utils (fromBool, toBool, with)
+import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Storable (peek, pokeByteOff)
+import GHC.Generics (Generic)
+import SDL (SDLException (SDLCallFailed), Surface (..))
 import SDL.Internal.Exception
-import SDL.Raw.Filesystem     (rwFromConstMem)
-import SDL.Vect               (V4(..))
+import SDL.Raw.Filesystem (rwFromConstMem)
+import SDL.Vect (V4 (..))
 
 import qualified SDL.Raw
 import qualified SDL.Raw.Font
@@ -505,7 +503,7 @@ blendedGlyph (Font font) (V4 r g b a) ch =
         with (SDL.Raw.Color r g b a) $ \fg ->
           SDL.Raw.Font.renderGlyph_Blended font (fromChar ch) fg
 
--- | Same as 'blended', but renders across multiple lines. 
+-- | Same as 'blended', but renders across multiple lines.
 --   Text is wrapped to multiple lines on line endings and on word boundaries
 --   if it extends beyond wrapLength in pixels.
 blendedWrapped :: MonadIO m => Font -> Color -> Int -> Text -> m SDL.Surface


### PR DESCRIPTION
This updates the package to compile with text-2.0, but with HEAD ghc-9.3.20220316 my test program (LambdaHack) segfaults, so I wasn't able to verify if it also works. If you do verify, please let me know.

Edit: of course this needs to be CPPd vs text-2.0.